### PR TITLE
Add dark mode toggle

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -27,7 +27,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en" suppressHydrationWarning>
+    <html lang="en" className="dark" suppressHydrationWarning>
       <body
         className={`min-h-screen flex flex-col bg-background text-foreground antialiased ${geistSans.variable} ${geistMono.variable}`}
       >

--- a/src/components/ui/Navbar.tsx
+++ b/src/components/ui/Navbar.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import clsx from "clsx";
 import DesktopNav from "./DesktopNav";
 import MobileNav from "./MobileNav";
+import ThemeToggle from "./ThemeToggle";
 
 export default function Navbar() {
   const [hidden, setHidden] = useState(false);
@@ -35,13 +36,16 @@ export default function Navbar() {
     >
       <div className="container mx-auto flex h-16 items-center justify-between px-4 sm:px-6 lg:px-8">
         <Link href="/" className="flex items-center space-x-2">
-          <img src="/logo.png" alt="Logo" className="h-8 w-auto sm:h-10" />
+          <img src="/logo.png" alt="Logo" className="h-8 w-auto sm:h-10 dark:invert" />
           <span className="text-lg font-semibold tracking-tight">
             The Digital Uplift
           </span>
         </Link>
         <DesktopNav />
-        <MobileNav />
+        <div className="flex items-center gap-2">
+          <ThemeToggle />
+          <MobileNav />
+        </div>
       </div>
     </header>
   );

--- a/src/components/ui/ThemeToggle.tsx
+++ b/src/components/ui/ThemeToggle.tsx
@@ -1,0 +1,39 @@
+"use client";
+import { useEffect, useState } from "react";
+import { Moon, Sun } from "lucide-react";
+
+export default function ThemeToggle() {
+  const [theme, setTheme] = useState<"light" | "dark">("dark");
+
+  useEffect(() => {
+    const stored = typeof window !== "undefined" ? localStorage.getItem("theme") : null;
+    if (stored === "light" || stored === "dark") {
+      setTheme(stored);
+      document.documentElement.classList.toggle("dark", stored === "dark");
+    } else {
+      document.documentElement.classList.add("dark");
+      localStorage.setItem("theme", "dark");
+    }
+  }, []);
+
+  const toggleTheme = () => {
+    const newTheme = theme === "dark" ? "light" : "dark";
+    setTheme(newTheme);
+    if (newTheme === "dark") {
+      document.documentElement.classList.add("dark");
+    } else {
+      document.documentElement.classList.remove("dark");
+    }
+    localStorage.setItem("theme", newTheme);
+  };
+
+  return (
+    <button
+      onClick={toggleTheme}
+      className="ml-2 p-2 rounded focus:outline-none focus-visible:ring"
+      aria-label="Toggle theme"
+    >
+      {theme === "dark" ? <Sun className="h-5 w-5" /> : <Moon className="h-5 w-5" />}
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
- default the site to dark mode
- add a theme toggle component
- update navbar with theme toggle and dark logo support

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68789e602ce4832ba3438074163b939b