### PR TITLE
Fix missing useEffect dependencies

### DIFF
--- a/src/components/ui/text-generate-effect.tsx
+++ b/src/components/ui/text-generate-effect.tsx
@@ -28,7 +28,7 @@ export const TextGenerateEffect = ({
         delay: stagger(0.2),
       }
     );
-  }, [scope.current]);
+  }, [animate, duration, filter, words]);
 
   const renderWords = () => {
     return (


### PR DESCRIPTION
## Summary
- address React hook dependency warning in `TextGenerateEffect`

## Testing
- `npm run lint` *(fails: `next` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68798b085228832bbb607ebf705d33d9