### PR TITLE
Fix type conflict for article page

### DIFF
--- a/src/app/articles/[slug]/page.tsx
+++ b/src/app/articles/[slug]/page.tsx
@@ -2,7 +2,7 @@
 import { notFound } from 'next/navigation';
 import { articles } from '@/lib/data/articles';
 
-type PageProps = {
+type ArticlePageProps = {
   params: { slug: string };
 };
 
@@ -12,7 +12,7 @@ export async function generateStaticParams() {
   }));
 }
 
-export default async function ArticlePage({ params }: PageProps) {
+export default async function ArticlePage({ params }: ArticlePageProps) {
   const article = articles.find((a) => a.slug === params.slug);
 
   if (!article) return notFound();


### PR DESCRIPTION
## Summary
- rename PageProps to avoid Next.js type conflict

## Testing
- `npm run lint` *(fails: `next: not found`)*
- `npm run build` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_688200950304832bb1564e1b08c825ed