### PR TITLE
Add SEO tags to article metadata

### DIFF
--- a/src/app/articles/[slug]/head.tsx
+++ b/src/app/articles/[slug]/head.tsx
@@ -1,17 +1,19 @@
 // app/articles/[slug]/head.tsx
+import type { Metadata } from 'next';
 import { articles } from '@/lib/data/articles';
 
 type HeadProps = {
   params: { slug: string };
 };
 
-export async function generateMetadata({ params }: HeadProps) {
+export async function generateMetadata({ params }: HeadProps): Promise<Metadata> {
   const article = articles.find((a) => a.slug === params.slug);
   if (!article) return {};
 
   return {
     title: article.title,
     description: `Explore "${article.title}" — insights on modern web design, dev tools, UX trends, and strategy.`,
+    keywords: article.tags,
     openGraph: {
       title: article.title,
       description: `Explore "${article.title}" — insights on modern web design, dev tools, UX trends, and strategy.`,
@@ -19,11 +21,15 @@ export async function generateMetadata({ params }: HeadProps) {
       siteName: 'The Digital Uplift',
       locale: 'en_CA',
       type: 'article',
+      tags: article.tags,
     },
     twitter: {
       card: 'summary_large_image',
       title: article.title,
       description: `Explore "${article.title}" — insights on modern web design, dev tools, UX trends, and strategy.`,
+    },
+    alternates: {
+      canonical: `https://yourdomain.com/articles/${article.slug}`,
     },
   };
 }

--- a/src/lib/data/articles.ts
+++ b/src/lib/data/articles.ts
@@ -19,27 +19,88 @@ export interface ArticleMeta {
   title: string;
   slug: string;
   component: () => JSX.Element;
+  tags: string[];
 }
 
 const slugify = (title: string) =>
   title.toLowerCase().replace(/[^\w\s]/g, '').replace(/\s+/g, '-');
 
 const rawArticles = [
-  { title: 'Web Design & Dev', component: articleone },
-  { title: 'Modern Design Tools', component: articletwo },
-  { title: 'Web Strategy Deep Dive', component: articlethree },
-  { title: 'Future of Web', component: articlefour },
-  { title: 'Digital Craft', component: articlefive },
-  { title: 'Web Design Evolution', component: articlesix },
-  { title: 'Web Innovation Frontier', component: articleseven },
-  { title: 'Custom Design in Ecommerce', component: articleeight },
-  { title: 'Freelance Design Future', component: articlenine },
-  { title: 'HTML & CSS Today', component: articleten },
-  { title: 'Modern Design & Function', component: articleeleven },
-  { title: 'Specialized SEO & UX', component: articletwelve },
-  { title: 'Web Agency Evolution', component: articlethirteen },
-  { title: 'Dev & Design Guide', component: articlefourteen },
-  { title: 'Web Solutions Overview', component: articlefifteen },
+  {
+    title: 'Web Design & Dev',
+    component: articleone,
+    tags: ['web design', 'development', 'business'],
+  },
+  {
+    title: 'Modern Design Tools',
+    component: articletwo,
+    tags: ['design tools', 'web trends', 'coding'],
+  },
+  {
+    title: 'Web Strategy Deep Dive',
+    component: articlethree,
+    tags: ['strategy', 'UX', 'performance'],
+  },
+  {
+    title: 'Future of Web',
+    component: articlefour,
+    tags: ['future', 'web development', 'innovation'],
+  },
+  {
+    title: 'Digital Craft',
+    component: articlefive,
+    tags: ['digital craft', 'custom design', 'branding'],
+  },
+  {
+    title: 'Web Design Evolution',
+    component: articlesix,
+    tags: ['evolution', 'ui', 'ux'],
+  },
+  {
+    title: 'Web Innovation Frontier',
+    component: articleseven,
+    tags: ['innovation', 'frontier', 'modern web'],
+  },
+  {
+    title: 'Custom Design in Ecommerce',
+    component: articleeight,
+    tags: ['ecommerce', 'custom design', 'shopping'],
+  },
+  {
+    title: 'Freelance Design Future',
+    component: articlenine,
+    tags: ['freelance', 'web design', 'future'],
+  },
+  {
+    title: 'HTML & CSS Today',
+    component: articleten,
+    tags: ['html', 'css', 'modern'],
+  },
+  {
+    title: 'Modern Design & Function',
+    component: articleeleven,
+    tags: ['design', 'function', 'usability'],
+  },
+  {
+    title: 'Specialized SEO & UX',
+    component: articletwelve,
+    tags: ['SEO', 'UX', 'accessibility'],
+  },
+  {
+    title: 'Web Agency Evolution',
+    component: articlethirteen,
+    tags: ['agency', 'evolution', 'digital'],
+  },
+  {
+    title: 'Dev & Design Guide',
+    component: articlefourteen,
+    tags: ['development', 'design', 'guide'],
+  },
+  {
+    title: 'Web Solutions Overview',
+    component: articlefifteen,
+    tags: ['web solutions', 'overview', 'services'],
+  },
 ];
 
 


### PR DESCRIPTION
## Summary
- add `tags` property to each article meta
- expand metadata generation to include keywords, tags and canonical url

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882f68d0930832b8732d307a249f68f