### PR TITLE
Add metadata to remaining pages

### DIFF
--- a/src/app/about-the-digital-uplift/page.tsx
+++ b/src/app/about-the-digital-uplift/page.tsx
@@ -1,5 +1,41 @@
 import Image from "next/image";
 import { cn } from "@/lib/utils";
+import { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "About – The Digital Uplift",
+  description:
+    "Explore the story, mission, and craft behind The Digital Uplift's high-performance websites for Canadian businesses.",
+  openGraph: {
+    title: "About – The Digital Uplift",
+    description:
+      "Learn how The Digital Uplift builds fast, future-ready digital experiences for Canadian businesses.",
+    url: "https://www.thedigitaluplift.ca/about-the-digital-uplift",
+    siteName: "The Digital Uplift",
+    images: [
+      {
+        url: "/hero-bg.png",
+        width: 1200,
+        height: 630,
+        alt: "High-performance web design for Canadian businesses",
+      },
+    ],
+    locale: "en_CA",
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "About – The Digital Uplift",
+    description:
+      "Get to know our mission and approach to crafting ultra-fast, accessible websites.",
+    images: [
+      {
+        url: "/hero-bg.png",
+        alt: "High-performance web design for Canadian businesses",
+      },
+    ],
+  },
+};
 
 const sections = [
   {

--- a/src/app/why-our-sites-score-100-in-seo-and-accessibility/page.tsx
+++ b/src/app/why-our-sites-score-100-in-seo-and-accessibility/page.tsx
@@ -1,3 +1,40 @@
+import { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Why Our Sites Score 100 in SEO and Accessibility – The Digital Uplift",
+  description:
+    "Discover the practices that help our builds earn perfect SEO and accessibility scores, from semantic HTML to blazing-fast performance.",
+  openGraph: {
+    title: "Why Our Sites Score 100 in SEO and Accessibility",
+    description:
+      "Learn how The Digital Uplift delivers websites that achieve perfect SEO and accessibility marks for Canadian businesses.",
+    url: "https://www.thedigitaluplift.ca/why-our-sites-score-100-in-seo-and-accessibility",
+    siteName: "The Digital Uplift",
+    images: [
+      {
+        url: "/hero-bg.png",
+        width: 1200,
+        height: 630,
+        alt: "High-performance web design for Canadian businesses",
+      },
+    ],
+    locale: "en_CA",
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Why Our Sites Score 100 in SEO and Accessibility",
+    description:
+      "See the development choices that power our perfect SEO and accessibility scores.",
+    images: [
+      {
+        url: "/hero-bg.png",
+        alt: "High-performance web design for Canadian businesses",
+      },
+    ],
+  },
+};
+
 export default function Page() {
   return <div>why our sites score 100 in seo and accessibility</div>;
 }


### PR DESCRIPTION
## Summary
- add openGraph and Twitter metadata to About page
- add openGraph and Twitter metadata to "Why Our Sites Score 100 in SEO and Accessibility" page

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689462327528832ba8614455ecc21a13