### PR TITLE
chore: force static rendering for static components

### DIFF
--- a/src/components/ui/DesktopNav.tsx
+++ b/src/components/ui/DesktopNav.tsx
@@ -1,4 +1,4 @@
-"use client";
+export const dynamic = "force-static"
 
 import Link from "next/link";
 import BookingModalTrigger from "@/components/ui/BookingModalTrigger";

--- a/src/components/ui/separator.tsx
+++ b/src/components/ui/separator.tsx
@@ -1,4 +1,4 @@
-"use client"
+export const dynamic = "force-static"
 
 import * as React from "react"
 import * as SeparatorPrimitive from "@radix-ui/react-separator"


### PR DESCRIPTION
## Summary
- replace unnecessary `use client` directives with `dynamic = 'force-static'` in static-only components

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894652c1b60832b94fb31e42fdd121f