### PR TITLE
feat: integrate botpress webchat globally

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,7 @@ import Navbar from "@/components/ui/Navbar";
 import Footer from "@/components/ui/Footer";
 import { BookingModalProvider } from "@/components/ui/BookingModalContext";
 import BookingModal from "@/components/ui/BookingModal";
+import BotpressWebchat from "@/components/ui/BotpressWebchat";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -119,6 +120,7 @@ export default function RootLayout({
           </main>
           <Footer />
           <BookingModal />
+          <BotpressWebchat />
         </BookingModalProvider>
       </body>
     </html>

--- a/src/components/ui/BotpressWebchat.tsx
+++ b/src/components/ui/BotpressWebchat.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { useState } from 'react';
+import {
+  Webchat,
+  WebchatProvider,
+  Fab,
+  getClient,
+  Configuration,
+} from '@botpress/webchat';
+
+const clientId = 'bbd2623c-885d-43ea-be09-3622056ccc0c';
+
+const configuration: Configuration = {
+  color: '#000',
+};
+
+const client = getClient({
+  clientId,
+});
+
+export default function BotpressWebchat() {
+  const [isWebchatOpen, setIsWebchatOpen] = useState(false);
+
+  const toggleWebchat = () => {
+    setIsWebchatOpen((prevState) => !prevState);
+  };
+
+  return (
+    <WebchatProvider client={client} configuration={configuration}>
+      <Fab onClick={toggleWebchat} />
+      <div
+        style={{
+          display: isWebchatOpen ? 'block' : 'none',
+        }}
+      >
+        <Webchat />
+      </div>
+    </WebchatProvider>
+  );
+}


### PR DESCRIPTION
## Summary
- add BotpressWebchat client component
- render BotpressWebchat in root layout for site-wide chat access

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c15ce8a04832b98c71e2c77901096