### PR TITLE
Use script injection for Botpress webchat

### DIFF
--- a/src/components/ui/BotpressWebchat.tsx
+++ b/src/components/ui/BotpressWebchat.tsx
@@ -1,25 +1,23 @@
 'use client';
 
-import { useState } from 'react';
-import dynamic from 'next/dynamic';
-import type { Configuration } from '@botpress/webchat';
-
-// Load Botpress widgets only on the client
-const Webchat = dynamic(() => import('@botpress/webchat').then(m => m.Webchat), { ssr: false });
-const Fab = dynamic(() => import('@botpress/webchat').then(m => m.Fab), { ssr: false });
+import Script from 'next/script';
 
 const clientId = 'bbd2623c-885d-43ea-be09-3622056ccc0c';
 
-const configuration: Configuration = {
-  color: '#000',
-};
-
 export default function BotpressWebchat() {
-  const [open, setOpen] = useState(false);
   return (
     <>
-      <Fab onClick={() => setOpen(v => !v)} />
-      {open && <Webchat clientId={clientId} configuration={configuration} />}
+      <Script
+        src="https://cdn.botpress.cloud/webchat/v1/inject.js"
+        strategy="afterInteractive"
+      />
+      <Script id="botpress-webchat-init" strategy="afterInteractive">
+        {`
+          window.botpressWebChat.init({
+            clientId: '${clientId}'
+          });
+        `}
+      </Script>
     </>
   );
 }


### PR DESCRIPTION
## Summary
- Replace Botpress React component with script-based initialization to avoid ReactCurrentDispatcher error

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c27a1de40832ba9e9d8b1a0659f4e