### PR TITLE
Add Webchat widget component

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,7 @@ import Navbar from "@/components/ui/Navbar";
 import Footer from "@/components/ui/Footer";
 import { BookingModalProvider } from "@/components/ui/BookingModalContext";
 import BookingModal from "@/components/ui/BookingModal";
+import WebchatWidget from "@/components/ui/WebchatWidget";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -119,6 +120,7 @@ export default function RootLayout({
           </main>
           <Footer />
           <BookingModal />
+          <WebchatWidget />
         </BookingModalProvider>
       </body>
     </html>

--- a/src/components/ui/WebchatWidget.tsx
+++ b/src/components/ui/WebchatWidget.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { Fab, Webchat } from "@botpress/webchat";
+import { useState } from "react";
+
+export default function WebchatWidget() {
+  const [isWebchatOpen, setIsWebchatOpen] = useState(false);
+  const toggleWebchat = () => {
+    setIsWebchatOpen((prevState) => !prevState);
+  };
+  return (
+    <>
+      <Webchat
+        clientId="bbd2623c-885d-43ea-be09-3622056ccc0c"
+        style={{
+          width: "400px",
+          height: "600px",
+          display: isWebchatOpen ? "flex" : "none",
+          position: "fixed",
+          bottom: "90px",
+          right: "20px",
+        }}
+      />
+      <Fab
+        onClick={toggleWebchat}
+        style={{
+          position: "fixed",
+          bottom: "20px",
+          right: "20px",
+          width: "64px",
+          height: "64px",
+        }}
+      />
+    </>
+  );
+}
+

--- a/src/types/botpress-webchat.d.ts
+++ b/src/types/botpress-webchat.d.ts
@@ -1,0 +1,5 @@
+declare module "@botpress/webchat" {
+  import type { ComponentType } from "react";
+  export const Webchat: ComponentType<unknown>;
+  export const Fab: ComponentType<unknown>;
+}


### PR DESCRIPTION
## Summary
- add `WebchatWidget` component with Botpress `Webchat` and `Fab`
- declare module for `@botpress/webchat`
- include widget in root layout for site-wide chat access

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c2c733fbc832bbe34ded9f65f3ff8