### PR TITLE
fix missing luxon types

### DIFF
--- a/types/luxon.d.ts
+++ b/types/luxon.d.ts
@@ -1,0 +1,3 @@
+declare module 'luxon' {
+  export const DateTime: any
+}


### PR DESCRIPTION
## Summary
- add stub declaration for `luxon` module so TypeScript compiles

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Geist`)*

------
https://chatgpt.com/codex/tasks/task_e_689c4827d740832bb7f01230c80077fa